### PR TITLE
Update macOS CI workflow for chezmoi login prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - "**"
   workflow_dispatch:
 
 jobs:
@@ -32,10 +28,10 @@ jobs:
       - name: Configure chezmoi
         run: |
           mkdir -p "$HOME/.config/chezmoi"
-          cat <<EOC > "$HOME/.config/chezmoi/chezmoi.toml"
-sourceDir = "$CHEZMOI_SOURCE_DIR"
-destinationDir = "$CHEZMOI_DEST_DIR"
-EOC
+          printf '%s\n' \
+            "sourceDir = \"$CHEZMOI_SOURCE_DIR\"" \
+            "destinationDir = \"$CHEZMOI_DEST_DIR\"" \
+            > "$HOME/.config/chezmoi/chezmoi.toml"
 
       - name: Apply dotfiles with chezmoi
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          path: ${{ steps.prepare_home.outputs.temp_home }}/.local/share/chezmoi
 
       - name: Install dependencies
         run: |
@@ -30,7 +28,7 @@ jobs:
         env:
           HOME: ${{ steps.prepare_home.outputs.temp_home }}
         run: |
-          chezmoi apply --verbose
+          chezmoi -S "$GITHUB_WORKSPACE" apply --verbose
 
       - name: Verify zsh login prompt
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  chezmoi:
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare home directory
+        run: |
+          temp_home=$(mktemp -d)
+          echo "HOME=$temp_home" >> "$GITHUB_ENV"
+          echo "CHEZMOI_SOURCE_DIR=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          echo "CHEZMOI_DEST_DIR=$temp_home" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: |
+          brew install chezmoi fish
+
+      - name: Configure chezmoi
+        run: |
+          mkdir -p "$HOME/.config/chezmoi"
+          cat <<EOC > "$HOME/.config/chezmoi/chezmoi.toml"
+sourceDir = "$CHEZMOI_SOURCE_DIR"
+destinationDir = "$CHEZMOI_DEST_DIR"
+EOC
+
+      - name: Apply dotfiles with chezmoi
+        run: |
+          chezmoi apply --verbose --include=files --include=symlinks
+
+      - name: Verify zsh login prompt
+        run: |
+          output=$(zsh -lic 'exit')
+          echo "$output"
+          grep "Welcome to zsh!" <<< "$output"
+
+      - name: Verify fish login prompt
+        run: |
+          output=$(fish -lic 'exit')
+          echo "$output"
+          grep "Welcome to fish!" <<< "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
             "destinationDir = \"$CHEZMOI_DEST_DIR\"" \
             > "$HOME/.config/chezmoi/chezmoi.toml"
 
+      - name: Expose repository dotfiles directory
+        run: |
+          ln -sfn "$CHEZMOI_SOURCE_DIR/dotfiles" "$HOME/dotfiles"
+
       - name: Apply dotfiles with chezmoi
         run: |
           chezmoi apply --verbose --include=files --include=symlinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,10 @@ jobs:
             "destinationDir = \"$CHEZMOI_DEST_DIR\"" \
             > "$HOME/.config/chezmoi/chezmoi.toml"
 
-      - name: Expose repository dotfiles directory
-        run: |
-          ln -sfn "$CHEZMOI_SOURCE_DIR/dotfiles" "$HOME/dotfiles"
-
       - name: Apply dotfiles with chezmoi
         run: |
-          chezmoi apply --verbose --include=files --include=symlinks
+          chezmoi apply --verbose --include=files
+          chezmoi apply --verbose --include=symlinks
 
       - name: Verify zsh login prompt
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches:
+      - "**"
   pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
 
 jobs:
   chezmoi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,40 +11,38 @@ jobs:
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Prepare home directory
+        id: prepare_home
         run: |
           temp_home=$(mktemp -d)
-          echo "HOME=$temp_home" >> "$GITHUB_ENV"
-          echo "CHEZMOI_SOURCE_DIR=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-          echo "CHEZMOI_DEST_DIR=$temp_home" >> "$GITHUB_ENV"
+          printf 'temp_home=%s\n' "$temp_home" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ steps.prepare_home.outputs.temp_home }}/.local/share/chezmoi
 
       - name: Install dependencies
         run: |
           brew install chezmoi fish
 
-      - name: Configure chezmoi
-        run: |
-          mkdir -p "$HOME/.config/chezmoi"
-          printf '%s\n' \
-            "sourceDir = \"$CHEZMOI_SOURCE_DIR\"" \
-            "destinationDir = \"$CHEZMOI_DEST_DIR\"" \
-            > "$HOME/.config/chezmoi/chezmoi.toml"
-
       - name: Apply dotfiles with chezmoi
+        env:
+          HOME: ${{ steps.prepare_home.outputs.temp_home }}
         run: |
-          chezmoi apply --verbose --include=files
-          chezmoi apply --verbose --include=symlinks
+          chezmoi apply --verbose
 
       - name: Verify zsh login prompt
+        env:
+          HOME: ${{ steps.prepare_home.outputs.temp_home }}
         run: |
           output=$(zsh -lic 'exit')
           echo "$output"
           grep "Welcome to zsh!" <<< "$output"
 
       - name: Verify fish login prompt
+        env:
+          HOME: ${{ steps.prepare_home.outputs.temp_home }}
         run: |
           output=$(fish -lic 'exit')
           echo "$output"

--- a/dotfiles/rust/install.fish
+++ b/dotfiles/rust/install.fish
@@ -1,12 +1,18 @@
 #!/usr/bin/env fish
 
+set -l toolchain 1.90.0
+
 fish_add_path --prepend $HOME/.cargo/bin
 
 if not type -q rustup
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path -y
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- --default-toolchain $toolchain --no-modify-path -y
 end
 
 fish_add_path --prepend $HOME/.cargo/bin
 
-rustup update 1> /dev/null
-    or abort "install rust"
+rustup toolchain install $toolchain 1> /dev/null
+    or abort "install rust $toolchain toolchain"
+
+rustup default $toolchain 1> /dev/null
+    or abort "set default rust toolchain"


### PR DESCRIPTION
## Summary
- add a macOS GitHub Actions job that applies the dotfiles with chezmoi in a temporary home
- verify the zsh and fish login welcome prompts still work without installing fish plugins

## Testing
- GitHub Actions

------
https://chatgpt.com/codex/tasks/task_e_68f3ad7437e8832192739cfe0312b4a5